### PR TITLE
load genesisState statically

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,4 @@
-var params = module.exports = require('./params.json')
+var params = require('./params.json')
+params.genesisState = require('./genesisState.json')
 
-//load it dynamical because it's slow
-Object.defineProperties(params, {
-  genesisState: {
-    get: require.bind(this, './genesisState.json')
-  }
-})
+module.exports = params


### PR DESCRIPTION
Loading genesisState dynamically throws off webpack:

```
WARNING in ./~/ethereum-common/index.js
Critical dependencies:
6:9-16 require function is used in a way in which dependencies cannot be statically extracted
 @ ./~/ethereum-common/index.js 6:9-16
```
