### PR TITLE
New release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 
-## [0.2.0] - Unreleased (``master`` branch)
+## [0.2.0] - 2017-10-11
 - ``Metro-Byzantium`` compatible
 - Block reward reduction
 - Added gas costs for curve operation precompiles (``ecAddGas``, ``ecMulGas``,...)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ethereum-common",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Resources common to all Ethereum implementations",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Versioned Byzantium release, will be published on npm after merge.

See https://github.com/ethereumjs/ethereumjs-vm/issues/209