### PR TITLE
Updated bootstrap nodes 

### DIFF
--- a/bootstrapNodes.json
+++ b/bootstrapNodes.json
@@ -2,21 +2,91 @@
   {
     "ip": "52.16.188.185",
     "port": "30303",
-    "id": "a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c"
+    "id": "a979fb575495b8d6db44f750317d0f4622bf4c2aa3365d6af7c284339968eef29b69ad0dce72a4d8db5ebb4968de0e3bec910127f134779fbcb0cb6d3331163c",
+    "network": "Mainnet",
+    "chainId": 1,
+    "location": "IE",
+    "comment": "Go Bootnode"
   },
   {
-    "ip": "54.94.239.50",
+    "ip": "13.93.211.84",
     "port": "30303",
-    "id": "de471bccee3d042261d52e9bff31458daecc406142b401d4cd848f677479f73104b9fdeb090af9583d3391b7f10cb2ba9e26865dd5fca4fcdc0fb1e3b723c786"
+    "id": "3f1d12044546b76342d59d4a05532c14b85aa669704bfe1f864fe079415aa2c02d743e03218e57a33fb94523adb54032871a6c51b2cc5514cb7c7e35b3ed0a99",
+    "network": "Mainnet",
+    "chainId": 1,
+    "location": "US-WEST",
+    "comment": "Go Bootnode"
+  },
+  {
+    "ip": "191.235.84.50",
+    "port": "30303",
+    "id": "78de8a0916848093c73790ead81d1928bec737d565119932b98c6b100d944b7a95e94f847f689fc723399d2e31129d182f7ef3863f2b4c820abbf3ab2722344d",
+    "network": "Mainnet",
+    "chainId": 1,
+    "location": "BR",
+    "comment": "Go Bootnode"
+  },
+  {
+    "ip": "13.75.154.138",
+    "port": "30303",
+    "id": "158f8aab45f6d19c6cbf4a089c2670541a8da11978a2f90dbf6a502a4a3bab80d288afdbeb7ec0ef6d92de563767f3b1ea9e8e334ca711e9f8e2df5a0385e8e6",
+    "network": "Mainnet",
+    "chainId": 1,
+    "location": "AU",
+    "comment": "Go Bootnode"
   },
   {
     "ip": "52.74.57.123",
     "port": "30303",
-    "id": "1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082"
+    "id": "1118980bf48b0a3640bdba04e0fe78b1add18e1cd99bf22d53daac1fd9972ad650df52176e7c7d89d1114cfef2bc23a2959aa54998a46afcf7d91809f0855082",
+    "network": "Mainnet",
+    "chainId": 1,
+    "location": "SG",
+    "comment": "Go Bootnode"
   },
   {
     "ip": "5.1.83.226",
     "port": "30303",
-    "id": "979b7fa28feeb35a4741660a16076f1943202cb72b6af70d327f053e248bab9ba81760f39d0701ef1d8f89cc1fbd2cacba0710a12cd5314d5e0c9021aa3637f9"
+    "id": "979b7fa28feeb35a4741660a16076f1943202cb72b6af70d327f053e248bab9ba81760f39d0701ef1d8f89cc1fbd2cacba0710a12cd5314d5e0c9021aa3637f9",
+    "network": "Mainnet",
+    "chainId": 1,
+    "location": "DE",
+    "comment": "Cpp Bootnode"
+  },
+  {
+    "ip": "13.84.180.240",
+    "port": "30303",
+    "id": "6ce05930c72abc632c58e2e4324f7c7ea478cec0ed4fa2528982cf34483094e9cbc9216e7aa349691242576d552a2a56aaeae426c5303ded677ce455ba1acd9d",
+    "network": "Ropsten",
+    "chainId": 3,
+    "location": "US-TX",
+    "comment": ""
+  },
+  {
+    "ip": "52.169.14.227",
+    "port": "30303",
+    "id": "20c9ad97c081d63397d7b685a412227a40e23c8bdc6688c6f37e97cfbc22d2b4d1db1510d8f61e6a8866ad7f0e17c02b14182d37ea7c3c8b9c2683aeb6b733a1",
+    "network": "Ropsten",
+    "chainId": 3,
+    "location": "IE",
+    "comment": ""
+  },
+  {
+    "ip": "52.169.42.101",
+    "port": "30303",
+    "id": "a24ac7c5484ef4ed0c5eb2d36620ba4e4aa13b8c84684e1b4aab0cebea2ae45cb4d375b77eab56516d34bfbd3c1a833fc51296ff084b770b94fb9028c4d25ccf",
+    "network": "Rinkeby",
+    "chainId": 4,
+    "location": "IE",
+    "comment": ""
+  },
+  {
+    "ip": "52.3.158.184",
+    "port": "30303",
+    "id": "343149e4feefa15d882d9fe4ac7d88f885bd05ebb735e547f12e12080a9fa07c8014ca6fd7f373123488102fe5e34111f8509cf0b7de3f5b44339c9f25e87cb8",
+    "network": "Rinkeby",
+    "chainId": 4,
+    "location": "",
+    "comment": "INFURA"
   }
 ]


### PR DESCRIPTION
Updated bootstrap nodes  according to node list from go-ethereum [bootnodes.go](https://github.com/ethereum/go-ethereum/blob/79b11121a7e4beef0d0297894289200b9842c36c/params/bootnodes.go) list.